### PR TITLE
Add support for x509

### DIFF
--- a/cmd/internal/cli/sign.go
+++ b/cmd/internal/cli/sign.go
@@ -17,12 +17,16 @@ import (
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	"github.com/apptainer/apptainer/pkg/sylog"
 	"github.com/apptainer/apptainer/pkg/sypgp"
+	"github.com/apptainer/sif/v2/pkg/integrity"
 	"github.com/spf13/cobra"
 )
 
 var (
 	privKey int // -k encryption key (index from 'key list --secret') specification
 	signAll bool
+
+	PKCS8PrivateKey string // -p path to PKCS8 private key specification
+	x509Cert        string // -c path to X509 certificate specification
 )
 
 // -g|--group-id
@@ -75,6 +79,26 @@ var signKeyIdxFlag = cmdline.Flag{
 	Usage:        "private key to use (index from 'key list --secret')",
 }
 
+// -p|--pkcs8Key
+var signPKCS8KeyFlag = cmdline.Flag{
+	ID:           "signPKCS8PrivateKeyFlag",
+	Value:        &PKCS8PrivateKey,
+	DefaultValue: "~/.apptainer/keys/pkcs8.key",
+	Name:         "pkcs8key",
+	ShortHand:    "p",
+	Usage:        "path to PKCS8 private key to use",
+}
+
+// -c |--x509cert
+var signX509CertFlag = cmdline.Flag{
+	ID:           "signX509CertFlag",
+	Value:        &x509Cert,
+	DefaultValue: "~/.apptainer/keys/cert.pem",
+	Name:         "x509Cert",
+	ShortHand:    "c",
+	Usage:        "path to X509 certificate to use",
+}
+
 // -a|--all (deprecated)
 var signAllFlag = cmdline.Flag{
 	ID:           "signAllFlag",
@@ -95,6 +119,8 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&signSifDescSifIDFlag, SignCmd)
 		cmdManager.RegisterFlagForCmd(&signSifDescIDFlag, SignCmd)
 		cmdManager.RegisterFlagForCmd(&signKeyIdxFlag, SignCmd)
+		cmdManager.RegisterFlagForCmd(&signPKCS8KeyFlag, SignCmd)
+		cmdManager.RegisterFlagForCmd(&signX509CertFlag, SignCmd)
 		cmdManager.RegisterFlagForCmd(&signAllFlag, SignCmd)
 	})
 }
@@ -118,16 +144,6 @@ var SignCmd = &cobra.Command{
 func doSignCmd(cmd *cobra.Command, cpath string) {
 	var opts []apptainer.SignOpt
 
-	// Set entity selector option, and ensure the entity is decrypted.
-	var f sypgp.EntitySelector
-	if cmd.Flag(signKeyIdxFlag.Name).Changed {
-		f = selectEntityAtIndex(privKey)
-	} else {
-		f = selectEntityInteractive()
-	}
-	f = decryptSelectedEntityInteractive(f)
-	opts = append(opts, apptainer.OptSignEntitySelector(f))
-
 	// Set group option, if applicable.
 	if cmd.Flag(signSifGroupIDFlag.Name).Changed || cmd.Flag(signOldSifGroupIDFlag.Name).Changed {
 		opts = append(opts, apptainer.OptSignGroup(sifGroupID))
@@ -136,6 +152,28 @@ func doSignCmd(cmd *cobra.Command, cpath string) {
 	// Set object option, if applicable.
 	if cmd.Flag(signSifDescSifIDFlag.Name).Changed || cmd.Flag(signSifDescIDFlag.Name).Changed {
 		opts = append(opts, apptainer.OptSignObjects(sifDescID))
+	}
+
+	// Set Signing method
+	switch {
+	case cmd.Flag(signPKCS8KeyFlag.Name).Changed: // Sign using X509
+		signer, err := integrity.GetX509Signer(PKCS8PrivateKey, x509Cert)
+		if err != nil {
+			sylog.Fatalf("Failed to get X509 signer: %s", err)
+		}
+
+		opts = append(opts, apptainer.OptSignX509(signer))
+
+	default: // Sign using PGP
+		// Set entity selector option, and ensure the entity is decrypted.
+		var f sypgp.EntitySelector
+		if cmd.Flag(signKeyIdxFlag.Name).Changed {
+			f = selectEntityAtIndex(privKey)
+		} else {
+			f = selectEntityInteractive()
+		}
+		f = decryptSelectedEntityInteractive(f)
+		opts = append(opts, apptainer.OptSignEntitySelector(f))
 	}
 
 	// Sign the image.

--- a/cmd/internal/cli/verify.go
+++ b/cmd/internal/cli/verify.go
@@ -11,14 +11,19 @@
 package cli
 
 import (
+	"crypto/x509"
 	"fmt"
 	"os"
 
+	"github.com/ProtonMail/go-crypto/openpgp"
 	"github.com/apptainer/apptainer/docs"
 	"github.com/apptainer/apptainer/internal/app/apptainer"
 	"github.com/apptainer/apptainer/internal/pkg/remote/endpoint"
 	"github.com/apptainer/apptainer/pkg/cmdline"
 	"github.com/apptainer/apptainer/pkg/sylog"
+	"github.com/apptainer/sif/v2/pkg/integrity"
+	"github.com/apptainer/sif/v2/pkg/sif"
+	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 )
 
@@ -29,6 +34,9 @@ var (
 	jsonVerify   bool   // -j flag
 	verifyAll    bool
 	verifyLegacy bool
+
+	x509RootCA            string // --x509RootCA
+	x509IntermediateCerts string // --x509IntermediateCerts
 )
 
 // -u|--url
@@ -122,6 +130,34 @@ var verifyLegacyFlag = cmdline.Flag{
 	Usage:        "enable verification of (insecure) legacy signatures",
 }
 
+// -c |--x509cert
+var verifyX509CertFlag = cmdline.Flag{
+	ID:           "verifyX509CertFlag",
+	Value:        &x509Cert,
+	DefaultValue: "~/.apptainer/keys/cert.pem",
+	Name:         "x509Cert",
+	ShortHand:    "c",
+	Usage:        "verify x509 signature using the cert",
+}
+
+// --x509RootCA
+var verifyX509RootCAFlag = cmdline.Flag{
+	ID:           "verifyX509RootCAFlag",
+	Value:        &x509RootCA,
+	DefaultValue: "~/.apptainer/keys/x509rootCA.pem",
+	Name:         "x509RootCA",
+	Usage:        "verify x509 cert using the root CA",
+}
+
+// --x509IntermediateCerts
+var verifyX509IntermediateCertsFlag = cmdline.Flag{
+	ID:           "verifyX509IntermediateCertsFlag",
+	Value:        &x509IntermediateCerts,
+	DefaultValue: "~/.apptainer/keys/x509intermediateCerts.pem",
+	Name:         "x509IntermediateCerts",
+	Usage:        "verify x509 cert using intermediate certs",
+}
+
 func init() {
 	addCmdInit(func(cmdManager *cmdline.CommandManager) {
 		cmdManager.RegisterCmd(VerifyCmd)
@@ -135,6 +171,10 @@ func init() {
 		cmdManager.RegisterFlagForCmd(&verifyJSONFlag, VerifyCmd)
 		cmdManager.RegisterFlagForCmd(&verifyAllFlag, VerifyCmd)
 		cmdManager.RegisterFlagForCmd(&verifyLegacyFlag, VerifyCmd)
+
+		cmdManager.RegisterFlagForCmd(&verifyX509CertFlag, VerifyCmd)
+		cmdManager.RegisterFlagForCmd(&verifyX509RootCAFlag, VerifyCmd)
+		cmdManager.RegisterFlagForCmd(&verifyX509IntermediateCertsFlag, VerifyCmd)
 	})
 }
 
@@ -156,6 +196,74 @@ var VerifyCmd = &cobra.Command{
 
 func doVerifyCmd(cmd *cobra.Command, cpath string) {
 	var opts []apptainer.VerifyOpt
+
+	// Set X509 verification, if applicable.
+	if cmd.Flag(verifyX509CertFlag.Name).Changed {
+		// Load the signature-signing X509 Certificate
+		leafCerts, err := integrity.NewChainedCertificates(x509Cert)
+		if err != nil {
+			sylog.Fatalf("Failed to get the signature-signing X509 certificate: %s", err)
+		}
+
+		signatureSigningCert, err := leafCerts.GetCertificate()
+		if err != nil {
+			sylog.Fatalf("Failed to get the signature-signing X509 certificate: %s", err)
+		}
+
+		// If the certificate is not self-signed, then we need the certificate of the authority who
+		// signed the certificate.
+		if signatureSigningCert.Issuer.String() != signatureSigningCert.Subject.String() {
+			sylog.Infof("Certificate '%s' requires Intermediate or Root CA certificates", x509Cert)
+
+			// Load Root CA Certificates (to validate intermediate or root certificates)
+			// If user options are not defined, use the default system cert pool.
+			if !cmd.Flag(verifyX509RootCAFlag.Name).Changed {
+				x509RootCA = ""
+			}
+			rootCerts, err := integrity.NewChainedCertificates(x509RootCA)
+			if err != nil {
+				sylog.Fatalf("Failed to get the Root CA x509 certificate: %s", err)
+			}
+
+			// Load intermediate Certificates (to validate the leaf certificate)
+			var intermediateCerts integrity.ChainedCertificates
+
+			if cmd.Flag(verifyX509IntermediateCertsFlag.Name).Changed {
+				certs, err := integrity.NewChainedCertificates(x509IntermediateCerts)
+				if err != nil {
+					sylog.Fatalf("Failed to get the intermediate X509 certificates: %s", err)
+				}
+
+				intermediateCerts = certs
+			} else {
+				sylog.Infof("Skip intermediate certificates.")
+			}
+
+			// Offline verification of leafCerts
+			if err := leafCerts.Verify(intermediateCerts, rootCerts); err != nil {
+				sylog.Fatalf("validation of leaf certificate failed. Err: %s", err)
+			}
+
+			// Online revocation check
+			if err := leafCerts.RevocationCheck(intermediateCerts, rootCerts); err != nil {
+				sylog.Fatalf("Online revocation check failed. Err: %s", err)
+			}
+		}
+
+		// Validate the signature using X509 certificate
+		opts = append(opts, apptainer.OptVerifyUseX509Cert(signatureSigningCert))
+
+	} else {
+		// Set PGP keyserver option, if applicable.
+		if !localVerify {
+			co, err := getKeyserverClientOpts(keyServerURI, endpoint.KeyserverVerifyOp)
+			if err != nil {
+				sylog.Fatalf("Error while getting keyserver client config: %v", err)
+			}
+
+			opts = append(opts, apptainer.OptVerifyUseKeyServer(co...))
+		}
+	}
 
 	// Set keyserver option, if applicable.
 	if !localVerify {
@@ -214,4 +322,78 @@ func doVerifyCmd(cmd *cobra.Command, cpath string) {
 
 		fmt.Printf("Container verified: %s\n", cpath)
 	}
+}
+
+// outputVerify outputs a textual representation of r to stdout.
+func outputVerify(f *sif.FileImage, r integrity.VerifyResult) bool {
+	// Print signing entity info.
+	switch e := r.Entity().(type) {
+	case *openpgp.Entity:
+		if e == nil {
+			// This may happen if the image is signed with X509, but PGP flags are used.
+			sylog.Warningf("PGP Signer identity unknown")
+			return false
+		}
+
+		prefix := color.New(color.FgYellow).Sprint("[REMOTE]")
+
+		if isGlobal(e) {
+			prefix = color.New(color.FgCyan).Sprint("[GLOBAL]")
+		} else if isLocal(e) {
+			prefix = color.New(color.FgGreen).Sprint("[LOCAL]")
+		}
+
+		// Print identity, if possible.
+		if id := primaryIdentity(e); id != nil {
+			fmt.Printf("%-18v Signing entity: %v\n", prefix, id.Name)
+		} else {
+			sylog.Warningf("Primary identity unknown")
+		}
+
+		// Always print fingerprint.
+		fmt.Printf("%-18v Fingerprint: %X\n", prefix, e.PrimaryKey.Fingerprint)
+	case *x509.Certificate:
+		if e == nil {
+			// This may happen if the image is signed with PGP, but X509 flags are used.
+			sylog.Warningf("X509 Signer identity unknown")
+			return false
+		}
+
+		prefix := color.New(color.FgYellow).Sprint("[X509]")
+
+		// Always print fingerprint.
+		fmt.Printf("%-18v Subject: %s\n", prefix, e.Subject.String())
+	default:
+		sylog.Fatalf("unsupported method %s", e)
+	}
+
+	// Print table of signed objects.
+	if len(r.Verified()) > 0 {
+		fmt.Printf("Objects verified:\n")
+		fmt.Printf("%-4s|%-8s|%-8s|%s\n", "ID", "GROUP", "LINK", "TYPE")
+		fmt.Print("------------------------------------------------\n")
+	}
+	for _, od := range r.Verified() {
+		group := "NONE"
+		if gid := od.GroupID(); gid != 0 {
+			group = fmt.Sprintf("%d", gid)
+		}
+
+		link := "NONE"
+		if l, isGroup := od.LinkedID(); l != 0 {
+			if isGroup {
+				link = fmt.Sprintf("%d (G)", l)
+			} else {
+				link = fmt.Sprintf("%d", l)
+			}
+		}
+
+		fmt.Printf("%-4d|%-8s|%-8s|%s\n", od.ID(), group, link, od.DataType())
+	}
+
+	if err := r.Error(); err != nil {
+		fmt.Printf("\nError encountered during signature verification: %v\n", err)
+	}
+
+	return false
 }

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.18
 
 require (
 	github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2
-	github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b
+	github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895
 	github.com/adigunhammedolalekan/registry-auth v0.0.0-20200730122110-8cde180a3a60
 	github.com/apex/log v1.9.0
 	github.com/apptainer/container-key-client v0.8.0
@@ -78,6 +78,7 @@ require (
 	github.com/bugsnag/panicwrap v1.2.0 // indirect
 	github.com/cespare/xxhash/v2 v2.1.2 // indirect
 	github.com/cilium/ebpf v0.7.0 // indirect
+	github.com/cloudflare/circl v1.1.0 // indirect
 	github.com/containerd/cgroups v1.0.3 // indirect
 	github.com/containers/libtrust v0.0.0-20200511145503-9c3a6c22cd9a // indirect
 	github.com/containers/ocicrypt v1.1.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -81,8 +81,8 @@ github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb0
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2 h1:+vx7roKuyA63nhn5WAunQHLTznkw5W8b1Xc0dNjp83s=
 github.com/Netflix/go-expect v0.0.0-20220104043353-73e0943537d2/go.mod h1:HBCaDeC1lPdgDeDbhX8XFpy1jqjK0IBG8W5K+xYqA0w=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b h1:lcbBNuQhppsc7A5gjdHmdlqUqJfgGMylBdGyDs0j7G8=
-github.com/ProtonMail/go-crypto v0.0.0-20220517143526-88bb52951d5b/go.mod h1:z4/9nQmJSSwwds7ejkxaJwO37dru3geImFUdJlaLzQo=
+github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895 h1:NsReiLpErIPzRrnogAXYwSoU7txA977LjDGrbkewJbg=
+github.com/ProtonMail/go-crypto v0.0.0-20220824120805-4b6e5c587895/go.mod h1:UBYPn8k0D56RtnR8RFQMjmh4KrZzWJ5o7Z9SYjossQ8=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/purell v1.1.1/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -150,6 +150,7 @@ github.com/bugsnag/osext v0.0.0-20130617224835-0dd3f918b21b/go.mod h1:obH5gd0Bsq
 github.com/bugsnag/panicwrap v0.0.0-20151223152923-e2c28503fcd0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
 github.com/bugsnag/panicwrap v1.2.0 h1:OzrKrRvXis8qEvOkfcxNcYbOd2O7xXS2nnKMEMABFQA=
 github.com/bugsnag/panicwrap v1.2.0/go.mod h1:D/8v3kj0zr8ZAKg1AQ6crr+5VwKN5eIywRkfhyM/+dE=
+github.com/bwesterb/go-ristretto v1.2.0/go.mod h1:fUIoIZaG73pV5biE2Blr2xEzDoMj7NFEuV9ekS419A0=
 github.com/cenkalti/backoff/v4 v4.1.1/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
 github.com/cenkalti/backoff/v4 v4.1.3 h1:cFAlzYUlVYDysBEH2T5hyJZMh3+5+WCBvSnK6Q8UtC4=
 github.com/cenkalti/backoff/v4 v4.1.3/go.mod h1:scbssz8iZGpm3xbr14ovlUdkxfGXNInqkPWOWmG2CLw=
@@ -172,6 +173,8 @@ github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/cilium/ebpf v0.7.0 h1:1k/q3ATgxSXRdrmPfH8d7YK0GfqVsEKZAX9dQZvs56k=
 github.com/cilium/ebpf v0.7.0/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cloudflare/circl v1.1.0 h1:bZgT/A+cikZnKIwn7xL2OBj012Bmvho/o6RpRvv3GKY=
+github.com/cloudflare/circl v1.1.0/go.mod h1:prBCrKB9DV4poKZY1l9zBXg2QJY7mvgRvtMxxK7fi4I=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/cncf/udpa/go v0.0.0-20201120205902-5459f2c99403/go.mod h1:WmhPx2Nbnhtbo57+VJT5O0JRkEi1Wbu0z5j0R8u5Hbk=
 github.com/cncf/udpa/go v0.0.0-20210930031921-04548b0d99d4/go.mod h1:6pvJx4me5XPnfI9Z40ddWsdw2W/uZgQLFXToKeRcDiI=
@@ -1006,6 +1009,7 @@ golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210322153248-0c34fe9e7dc2/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e h1:T8NU3HyQ8ClP4SEE+KbFlg6n0NhuTsN4MyznaarGsZM=
 golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1186,10 +1190,12 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210426230700-d19ff857e887/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210927094055-39ccf1dd6fa6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20211007075335-d3039528d8ac/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211025201205-69cdffdb9359/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211116061358-0a5406a5449c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/app/apptainer/sign.go
+++ b/internal/app/apptainer/sign.go
@@ -37,6 +37,15 @@ func OptSignEntitySelector(f sypgp.EntitySelector) SignOpt {
 	}
 }
 
+// OptSignX509 specifies the entity to use to generate signature(s).
+func OptSignX509(f *integrity.X509Signer) SignOpt {
+	return func(s *signer) error {
+		s.opts = append(s.opts, integrity.OptSignWithEntity(f))
+
+		return nil
+	}
+}
+
 // OptSignGroup specifies that a signature be applied to cover all objects in the group with the
 // specified groupID. This may be called multiple times to add multiple group signatures.
 func OptSignGroup(groupID uint32) SignOpt {

--- a/internal/app/apptainer/verify.go
+++ b/internal/app/apptainer/verify.go
@@ -12,6 +12,7 @@ package apptainer
 
 import (
 	"context"
+	"crypto/x509"
 	"encoding/hex"
 	"errors"
 	"os"
@@ -37,6 +38,8 @@ type verifier struct {
 	all       bool
 	legacy    bool
 	cb        VerifyCallback
+
+	x509Cert *x509.Certificate
 }
 
 // VerifyOpt are used to configure v.
@@ -47,6 +50,14 @@ type VerifyOpt func(v *verifier) error
 func OptVerifyUseKeyServer(opts ...client.Option) VerifyOpt {
 	return func(v *verifier) error {
 		v.opts = opts
+		return nil
+	}
+}
+
+// OptVerifyUseX509Cert enables verification of x509 signatures.
+func OptVerifyUseX509Cert(cert *x509.Certificate) VerifyOpt {
+	return func(v *verifier) error {
+		v.x509Cert = cert
 		return nil
 	}
 }
@@ -110,31 +121,35 @@ func newVerifier(opts []VerifyOpt) (verifier, error) {
 func (v verifier) getOpts(ctx context.Context, f *sif.FileImage) ([]integrity.VerifierOpt, error) {
 	var iopts []integrity.VerifierOpt
 
-	// Add keyring.
-	var kr openpgp.KeyRing
-	if v.opts != nil {
-		hkr, err := sypgp.NewHybridKeyRing(ctx, v.opts...)
-		if err != nil {
-			return nil, err
-		}
-		kr = hkr
+	if v.x509Cert != nil {
+		iopts = append(iopts, integrity.OptVerifyWithSigner(v.x509Cert))
 	} else {
-		pkr, err := sypgp.PublicKeyRing()
+		// Add keyring.
+		var kr openpgp.KeyRing
+		if v.opts != nil {
+			hkr, err := sypgp.NewHybridKeyRing(ctx, v.opts...)
+			if err != nil {
+				return nil, err
+			}
+			kr = hkr
+		} else {
+			pkr, err := sypgp.PublicKeyRing()
+			if err != nil {
+				return nil, err
+			}
+			kr = pkr
+		}
+
+		// wrap the global keyring around
+		global := sypgp.NewHandle(buildcfg.APPTAINER_CONFDIR, sypgp.GlobalHandleOpt())
+		gkr, err := global.LoadPubKeyring()
 		if err != nil {
 			return nil, err
 		}
-		kr = pkr
-	}
+		kr = sypgp.NewMultiKeyRing(gkr, kr)
 
-	// wrap the global keyring around
-	global := sypgp.NewHandle(buildcfg.APPTAINER_CONFDIR, sypgp.GlobalHandleOpt())
-	gkr, err := global.LoadPubKeyring()
-	if err != nil {
-		return nil, err
+		iopts = append(iopts, integrity.OptVerifyWithSigner(kr))
 	}
-	kr = sypgp.NewMultiKeyRing(gkr, kr)
-
-	iopts = append(iopts, integrity.OptVerifyWithKeyRing(kr))
 
 	// Add group IDs, if applicable.
 	for _, groupID := range v.groupIDs {

--- a/internal/app/apptainer/verify_test.go
+++ b/internal/app/apptainer/verify_test.go
@@ -371,7 +371,7 @@ func TestVerify(t *testing.T) {
 					}
 				}
 
-				if got, want := r.Entity().PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
+				if got, want := r.Entity().(*openpgp.Entity).PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
 					t.Errorf("got entity public key %+v, want %+v", got, want)
 				}
 
@@ -543,7 +543,7 @@ func TestVerifyFingerPrint(t *testing.T) {
 					}
 				}
 
-				if got, want := r.Entity().PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
+				if got, want := r.Entity().(*openpgp.Entity).PrimaryKey, tt.wantEntity.PrimaryKey; !reflect.DeepEqual(got, want) {
 					t.Errorf("got entity public key %+v, want %+v", got, want)
 				}
 

--- a/internal/pkg/build/metadata.go
+++ b/internal/pkg/build/metadata.go
@@ -12,7 +12,7 @@ package build
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -79,7 +79,7 @@ func insertEnvScript(b *types.Bundle) error {
 		envScriptPath := filepath.Join(b.RootfsPath, "/.singularity.d/env/90-environment.sh")
 		_, err := os.Stat(envScriptPath)
 		if os.IsNotExist(err) {
-			err := ioutil.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
+			err := os.WriteFile(envScriptPath, []byte("#!/bin/sh\n\n"+b.Recipe.ImageData.Environment.Script+"\n"), 0o755)
 			if err != nil {
 				return err
 			}
@@ -126,7 +126,7 @@ func insertRunScript(b *types.Bundle) error {
 	if b.RunSection("runscript") && b.Recipe.ImageData.Runscript.Script != "" {
 		sylog.Infof("Adding runscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Runscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -138,7 +138,7 @@ func insertStartScript(b *types.Bundle) error {
 	if b.RunSection("startscript") && b.Recipe.ImageData.Startscript.Script != "" {
 		sylog.Infof("Adding startscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Startscript)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/startscript"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -150,7 +150,7 @@ func insertTestScript(b *types.Bundle) error {
 	if b.RunSection("test") && b.Recipe.ImageData.Test.Script != "" {
 		sylog.Infof("Adding testscript")
 		shebang, script := handleShebangScript(b.Recipe.ImageData.Test)
-		err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
+		err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/test"), []byte(shebang+"\n\n"+script+"\n"), 0o755)
 		if err != nil {
 			return err
 		}
@@ -163,7 +163,7 @@ func insertHelpScript(b *types.Bundle) error {
 		_, err := os.Stat(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"))
 		if err != nil || b.Opts.Force {
 			sylog.Infof("Adding help info")
-			err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
+			err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/runscript.help"), []byte(b.Recipe.ImageData.Help.Script+"\n"), 0o644)
 			if err != nil {
 				return err
 			}
@@ -186,7 +186,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 
 		// look at number of files in bootstrap_history to give correct file name
-		files, err := ioutil.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
+		files, err := os.ReadDir(filepath.Join(b.RootfsPath, "/.singularity.d/bootstrap_history"))
 		if err != nil {
 			return err
 		}
@@ -201,7 +201,7 @@ func insertDefinition(b *types.Bundle) error {
 		}
 	}
 
-	err := ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0o644)
+	err := os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/Singularity"), b.Recipe.Raw, 0o644)
 	if err != nil {
 		return err
 	}
@@ -219,7 +219,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 
 	// get labels added through APPTAINER_LABELS environment variables
 	buildLabels := filepath.Join(b.RootfsPath, sLabelsPath)
-	content, err := ioutil.ReadFile(buildLabels)
+	content, err := os.ReadFile(buildLabels)
 	if err == nil {
 		if err := os.Remove(filepath.Join(b.RootfsPath, sLabelsPath)); err != nil {
 			return err
@@ -261,7 +261,7 @@ func insertLabelsJSON(b *types.Bundle) (err error) {
 		return err
 	}
 
-	err = ioutil.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
+	err = os.WriteFile(filepath.Join(b.RootfsPath, "/.singularity.d/labels.json"), []byte(text), 0o644)
 	return err
 }
 
@@ -299,7 +299,7 @@ func getExistingLabels(labels map[string]string, b *types.Bundle) error {
 		}
 		defer jsonFile.Close()
 
-		jsonBytes, err := ioutil.ReadAll(jsonFile)
+		jsonBytes, err := io.ReadAll(jsonFile)
 		if err != nil {
 			return err
 		}

--- a/internal/pkg/syecl/syecl.go
+++ b/internal/pkg/syecl/syecl.go
@@ -27,7 +27,7 @@ import (
 	"github.com/apptainer/sif/v2/pkg/integrity"
 	"github.com/apptainer/sif/v2/pkg/sif"
 	"github.com/hashicorp/go-multierror"
-	toml "github.com/pelletier/go-toml"
+	"github.com/pelletier/go-toml"
 )
 
 var (
@@ -242,7 +242,7 @@ func shouldRun(ecl *EclConfig, fp *os.File, kr openpgp.KeyRing) (ok bool, err er
 	}
 	defer f.UnloadContainer()
 
-	opts := []integrity.VerifierOpt{integrity.OptVerifyWithKeyRing(kr)}
+	opts := []integrity.VerifierOpt{integrity.OptVerifyWithSigner(kr)}
 	if ecl.Legacy {
 		// Legacy behavior is to verify the primary partition only.
 		od, err := f.GetDescriptor(sif.WithPartitionType(sif.PartPrimSys))


### PR DESCRIPTION
Singularity/Apptainer supports the capability to use PGP keys for signing and verifying containers, thus improving the level of trust for users that need to share containers.

PGP is based on the "Web of Trust" principle, where communicating parties must have at least one trusted party in common, who will sign both keys. PGP relies on asymmetric cryptography (i.e., the creation and usage of public-private key pairs).

X.509 is an alternative security approach, also relying on asymmetric cryptography, but is usually deployed in environments where certification authorities (CAs) vouch for each certificate, meaning the overall system architecture needs a CA. Anyone who wants to participate in the system must have their keys signed by that CA. Certificate creation and validation rely on a chain of trust established among CAs.

However, sharing containers among Supercomputing Center (SC) customers assumes a trusting relationship with the code providers and the SC itself. We advocate that a Supercomputing Center can provide Public Key Infrastructure (PKI) services to its customers, assuming the CA's role in the trusted sharing of pre-validated codes that are packaged as container images. We consider use cases where containers include specialized software packages and libraries, including their configuration parameter settings, for HPC codes expected to operate on sensitive datasets in a wide range of scientific domains.

This PR implements the proposed extensions to the codebase of Singularity/Apptainer so that X.509 certificates, signed by the SC's CA, can be embedded in SIF-formatted container binary image files and then be checked online for validity (incl. checks for revocation).

Important Note: the X.509 certificates are supported without removing the existing support for PGP certificates.

